### PR TITLE
 Perf/orangeHRM: Added cypress origin feature to fix side menu TCs

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -4,6 +4,7 @@ const reportDate = (date.toLocaleString('default', { month: 'long' }))+" "+date.
 ":" + date.getSeconds();
 
 module.exports = defineConfig({
+  experimentalSessionAndOrigin: true,
   video: false,
   reporter: 'cypress-mochawesome-reporter',
   reporterOptions: {

--- a/cypress/e2e/Orange/04-orangeHR_Side_Menu_TCs.cy.js
+++ b/cypress/e2e/Orange/04-orangeHR_Side_Menu_TCs.cy.js
@@ -26,8 +26,9 @@ describe('Side Menu', () => {
 
   it('Click on the on OrangeHRM icon', ()=>{
     sidemenu.getBanner().click();
-    const newUrl = cy.url();
-    expect(Cypress.env('baseUrl')).to.not.equal(newUrl);
+    cy.origin(Cypress.env('prodURL'), ()=> {
+      cy.url().should('eq', Cypress.env('prodURL'));
+    });
   });
 
   it('Visit all side menu pages', ()=>{


### PR DESCRIPTION
# Changelog

* Added cypress origin `https://docs.cypress.io/api/commands/origin` to side menu TCs. 