### PR TITLE
Perf/orangeHRM: Add error handling fix for TCs

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -4,7 +4,6 @@ const reportDate = (date.toLocaleString('default', { month: 'long' }))+" "+date.
 ":" + date.getSeconds();
 
 module.exports = defineConfig({
-  experimentalSessionAndOrigin: true,
   video: false,
   reporter: 'cypress-mochawesome-reporter',
   reporterOptions: {

--- a/cypress/e2e/Orange/02-orangeHR_Dashboard_TCs.cy.js
+++ b/cypress/e2e/Orange/02-orangeHR_Dashboard_TCs.cy.js
@@ -7,6 +7,9 @@ describe('Dashboard Page', () => {
   beforeEach(function(){
     cy.login();
     cy.url().should('eq', Cypress.env('dashboardurl'));
+    Cypress.on('uncaught:exception', () => {
+      return false
+    });
   });
 
   afterEach(function(){

--- a/cypress/e2e/Orange/03-orangeHR_User_Profile_TCs.cy.js
+++ b/cypress/e2e/Orange/03-orangeHR_User_Profile_TCs.cy.js
@@ -7,7 +7,9 @@ const loginPage = new LoginPage();
 describe('User profile section', () => {
 
   beforeEach(function(){
-    cy.login();
+    cy.login();Cypress.on('uncaught:exception', () => {
+      return false
+    });
   });
 
   afterEach(function(){

--- a/cypress/e2e/Orange/04-orangeHR_Side_Menu_TCs.cy.js
+++ b/cypress/e2e/Orange/04-orangeHR_Side_Menu_TCs.cy.js
@@ -10,6 +10,9 @@ describe('Side Menu', () => {
   beforeEach(function(){
     cy.login();
     cy.url().should('eq', Cypress.env('dashboardurl'));
+    Cypress.on('uncaught:exception', () => {
+      return false
+    });
   });
 
   it('Collide Side Menu', ()=>{


### PR DESCRIPTION
# Changelog

* Added `Cypress.on('uncaught:exception', () => { return false});` to avoid errors from the target pages on TCs execution.
* Removed experimental properties used before for `cy.origin` from `cypress.config.js`


### Note

After the changes mentioned above, the framework became faster.